### PR TITLE
Add Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+tasks:
+- init: >
+    mkdir -p build &&
+    cd build &&
+    cmake -D CMAKE_EXPORT_COMPILE_COMMANDS=1 .. &&
+    make &&
+    cd ..

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,8 @@
+{
+   "cpp.buildConfigurations": [
+      {
+         "name": "Release",
+         "directory": "build"
+      }
+   ]
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ C/C++ Toy Problems
 
 This is not really a project. Just some simple example solutions to simple problems. All problems could be solved much better, but this is just for training purpose.
 Feel free to have a look but please don't expect tricky, fast or well designed solutions.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Shadouw/CPPToyProblems)


### PR DESCRIPTION
Hi @Shadouw! 👋

This is mostly your work from [Spectrum](https://spectrum.chat/gitpod/general/gitpod-and-c~f6f89cb1-be05-48ab-856b-1c75fba369e3) (thanks!) but this is how you'd make the C++/Theia configuration persistent across workspaces.

To try it out:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/CPPToyProblems)

Potential improvements / next steps:
- Enabling [cross-file references](https://github.com/theia-ide/theia/tree/master/packages/cpp#getting-cross-file-references-to-work)
- Enabling [clang-tidy linting](https://github.com/theia-ide/theia/tree/master/packages/cpp#using-the-clang-tidy-linter) (it can suggest really cool things [like this](https://clang.llvm.org/extra/clang-tidy/checks/performance-type-promotion-in-math-fn.html), but it's not installed in Gitpod workspaces yet. I'll fix that)